### PR TITLE
Get tests passing

### DIFF
--- a/spec/network.coffee
+++ b/spec/network.coffee
@@ -312,7 +312,7 @@ describe 'WebSocket network runtime', ->
 
   describe 'Network protocol', ->
     # Set up a clean graph
-    before (done) ->
+    beforeEach (done) ->
       waitFor = 4
       listener = (message) ->
         waitFor--
@@ -395,37 +395,37 @@ describe 'WebSocket network runtime', ->
         receive expects, done
         send 'network', 'getstatus',
           graph: 'bar'
-    describe 'on stopping the network', ->
-      it 'should be stopped', (done) ->
-        listener = (message) ->
-          check done, ->
-            chai.expect(message.utf8Data).to.be.a 'string'
-            msg = JSON.parse message.utf8Data
-            chai.expect(msg.protocol).to.equal 'network'
-            unless msg.command is 'stopped'
-              connection.once 'message', listener
-            else
-              chai.expect(msg.payload).to.be.an 'object'
-              chai.expect(msg.payload.graph).to.equal 'bar'
-              chai.expect(msg.payload.time).to.be.a 'string'
-              chai.expect(msg.payload.running).to.equal false
-              chai.expect(msg.payload.started).to.equal false
-              done()
-        connection.once 'message', listener
-        send 'network', 'stop',
-          graph: 'bar'
-      it "should provide a 'stopped' status", (done) ->
-        expects = [
-          protocol: 'network'
-          command: 'status'
-          payload:
+      describe 'on stopping the network', ->
+        it 'should be stopped', (done) ->
+          listener = (message) ->
+            check done, ->
+              chai.expect(message.utf8Data).to.be.a 'string'
+              msg = JSON.parse message.utf8Data
+              chai.expect(msg.protocol).to.equal 'network'
+              unless msg.command is 'stopped'
+                connection.once 'message', listener
+              else
+                chai.expect(msg.payload).to.be.an 'object'
+                chai.expect(msg.payload.graph).to.equal 'bar'
+                chai.expect(msg.payload.time).to.be.a 'string'
+                chai.expect(msg.payload.running).to.equal false
+                chai.expect(msg.payload.started).to.equal false
+                done()
+          connection.once 'message', listener
+          send 'network', 'stop',
             graph: 'bar'
-            running: false
-            started: false
-        ]
-        receive expects, done
-        send 'network', 'getstatus',
-          graph: 'bar'
+        it "should provide a 'stopped' status", (done) ->
+          expects = [
+            protocol: 'network'
+            command: 'status'
+            payload:
+              graph: 'bar'
+              running: false
+              started: false
+          ]
+          receive expects, done
+          send 'network', 'getstatus',
+            graph: 'bar'
     describe 'on console output', ->
       it 'should be able to capture and transmit it', (done) ->
         listener = (message) ->

--- a/spec/network.coffee
+++ b/spec/network.coffee
@@ -59,6 +59,14 @@ describe 'WebSocket network runtime', ->
       it 'should provide the nodes back', (done) ->
         expects = [
             protocol: 'graph'
+            command: 'clear',
+            payload: 
+              baseDir: path.resolve __dirname, '../'
+              id: 'foo'
+              main: true
+              name: 'NoFlo runtime'
+          ,
+            protocol: 'graph'
             command: 'addnode'
             payload:
               id: 'Foo'
@@ -80,8 +88,8 @@ describe 'WebSocket network runtime', ->
           baseDir: path.resolve __dirname, '../'
           id: 'foo'
           main: true
-        send 'graph', 'addnode', expects[0].payload
         send 'graph', 'addnode', expects[1].payload
+        send 'graph', 'addnode', expects[2].payload
     describe 'receiving an edge', ->
       it 'should provide the edge back', (done) ->
         expects = [
@@ -120,6 +128,19 @@ describe 'WebSocket network runtime', ->
       it 'should remove the node and its associated edges', (done) ->
         expects = [
           protocol: 'graph'
+          command: 'changeedge'
+          payload:
+            src:
+              node: 'Foo'
+              port: 'out'
+            tgt:
+              node: 'Bar'
+              port: 'in'
+            metadata:
+              route: 5
+            graph: 'foo'
+        ,
+          protocol: 'graph'
           command: 'removeedge'
           payload:
             src:
@@ -130,6 +151,13 @@ describe 'WebSocket network runtime', ->
               port: 'in'
             metadata:
               route: 5
+            graph: 'foo'
+        ,
+          protocol: 'graph'
+          command: 'changenode'
+          payload:
+            id: 'Bar'
+            metadata: {}
             graph: 'foo'
         ,
           protocol: 'graph'
@@ -266,13 +294,13 @@ describe 'WebSocket network runtime', ->
             expectedInPorts = [
               id: 'in'
               type: 'all'
-              required: true
+              required: false
               addressable: false
               description: 'Packet to be printed through console.log'
             ,
               id: 'options'
               type: 'object'
-              required: true
+              required: false
               addressable: false
               description: 'Options to be passed to console.log'
             ]
@@ -280,7 +308,7 @@ describe 'WebSocket network runtime', ->
             chai.expect(msg.payload.outPorts).to.eql [
               id: 'out'
               type: 'all'
-              required: true
+              required: false
               addressable: false
             ]
             done()

--- a/spec/network.coffee
+++ b/spec/network.coffee
@@ -313,7 +313,7 @@ describe 'WebSocket network runtime', ->
   describe 'Network protocol', ->
     # Set up a clean graph
     beforeEach (done) ->
-      waitFor = 4
+      waitFor = 5  # set this to the number of commands below
       listener = (message) ->
         waitFor--
         if waitFor
@@ -395,37 +395,37 @@ describe 'WebSocket network runtime', ->
         receive expects, done
         send 'network', 'getstatus',
           graph: 'bar'
-      describe 'on stopping the network', ->
-        it 'should be stopped', (done) ->
-          listener = (message) ->
-            check done, ->
-              chai.expect(message.utf8Data).to.be.a 'string'
-              msg = JSON.parse message.utf8Data
-              chai.expect(msg.protocol).to.equal 'network'
-              unless msg.command is 'stopped'
-                connection.once 'message', listener
-              else
-                chai.expect(msg.payload).to.be.an 'object'
-                chai.expect(msg.payload.graph).to.equal 'bar'
-                chai.expect(msg.payload.time).to.be.a 'string'
-                chai.expect(msg.payload.running).to.equal false
-                chai.expect(msg.payload.started).to.equal false
-                done()
-          connection.once 'message', listener
-          send 'network', 'stop',
+    describe 'on stopping the network', ->
+      it 'should be stopped', (done) ->
+        listener = (message) ->
+          check done, ->
+            chai.expect(message.utf8Data).to.be.a 'string'
+            msg = JSON.parse message.utf8Data
+            chai.expect(msg.protocol).to.equal 'network'
+            unless msg.command is 'stopped'
+              connection.once 'message', listener
+            else
+              chai.expect(msg.payload).to.be.an 'object'
+              chai.expect(msg.payload.graph).to.equal 'bar'
+              chai.expect(msg.payload.time).to.be.a 'string'
+              chai.expect(msg.payload.running).to.equal false
+              chai.expect(msg.payload.started).to.equal false
+              done()
+        connection.once 'message', listener
+        send 'network', 'stop',
+          graph: 'bar'
+      it "should provide a 'stopped' status", (done) ->
+        expects = [
+          protocol: 'network'
+          command: 'status'
+          payload:
             graph: 'bar'
-        it "should provide a 'stopped' status", (done) ->
-          expects = [
-            protocol: 'network'
-            command: 'status'
-            payload:
-              graph: 'bar'
-              running: false
-              started: false
-          ]
-          receive expects, done
-          send 'network', 'getstatus',
-            graph: 'bar'
+            running: false
+            started: false
+        ]
+        receive expects, done
+        send 'network', 'getstatus',
+          graph: 'bar'
     describe 'on console output', ->
       it 'should be able to capture and transmit it', (done) ->
         listener = (message) ->


### PR DESCRIPTION
Apparently there have been a few changes regarding when messages are sent, which caused these tests to fail.  Here's a quick summary:

- issuing a `graph removeedge` request produces a `changeedge` response before the `removeedge` response
- issuing a `graph removenode` request produces a `changenode` response before the `removenode` response
- issuing a `graph clear` request produces a `graph clear` response
- in and out ports of the `core/Output` component are now optional

Are all of these changes expected?  I'm particularly curious about the `changeedge` and `changenode` responses, since the metadata of the edges/nodes in question does not seem to have changed, so I'm not sure why this response would be emitted.

It seems to me that the request / response cycle is an important part of the FBP Network Protocol, but many of these details are not documented in the [FBP Networking Protocol docs](http://noflojs.org/documentation/protocol). It would be great if the page was more clear about the context that each message is sent.  For example, the [component](http://noflojs.org/documentation/protocol/#component) message is described as "Transmit the metadata about a component instance", which sounds like a request, but is actually a response to a `component list` request.  Also, as pointed out above, the [graph clear](http://noflojs.org/documentation/protocol/#graph) message is now both a request and a response, but the docs don't explain this or how the message structure differs when used as a response vs request.

My end goal at improving these tests is to create a testsuite that any websocket runtime -- written in any language -- can use to ensure complete FBP Network Protocol compatibility (eventually it would be good to abstract the transport too, if possible).  I'm currently looking into the [protoflo](https://github.com/jonnor/protoflo) python runtime and having a testsuite like this will save me a lot of headaches while trying to ensure noflo-ui compatibility.  I'm not a javascript/coffeescript expert, but I've made some decent progress in making these tests more reusable, which I'll be posting soon.  Maybe you'll have some feedback on how to improve my changes.

thanks!
