### PR TITLE
tests: use full path for fbp-test

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -15,7 +15,7 @@ module.exports = ->
         options:
           async: true
       fbp_test:
-        command: 'fbp-test --colors'
+        command: './node_modules/.bin/fbp-test --colors'
 
   # Grunt plugins used for testing
   @loadNpmTasks 'grunt-contrib-watch'


### PR DESCRIPTION
The fbp-test tool is not on the PATH. Use the full name instead.

Fixes #3